### PR TITLE
✨[FEAT] #3 - Fill 로고 커스텀 네비게이션 바 만들기

### DIFF
--- a/Fillin-iOS/Fillin-iOS.xcodeproj/project.pbxproj
+++ b/Fillin-iOS/Fillin-iOS.xcodeproj/project.pbxproj
@@ -39,7 +39,7 @@
 		775C96A8278AD8E600A9BEA0 /* SplashViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 775C96A6278AD8E600A9BEA0 /* SplashViewController.xib */; };
 		775C96AA278B2E1100A9BEA0 /* swiftgen.yml in Resources */ = {isa = PBXBuildFile; fileRef = 775C96A9278B2E1100A9BEA0 /* swiftgen.yml */; };
 		775C96B0278B33E200A9BEA0 /* Assets+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C96AF278B33E200A9BEA0 /* Assets+Generated.swift */; };
-		775C96B2278B5B3800A9BEA0 /* NavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C96B1278B5B3800A9BEA0 /* NavigationBar.swift */; };
+		775C96B2278B5B3800A9BEA0 /* FillinNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C96B1278B5B3800A9BEA0 /* FillinNavigationBar.swift */; };
 		775C96B4278B61D100A9BEA0 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C96B3278B61D100A9BEA0 /* UIView+Extension.swift */; };
 /* End PBXBuildFile section */
 
@@ -78,7 +78,7 @@
 		775C96A6278AD8E600A9BEA0 /* SplashViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SplashViewController.xib; sourceTree = "<group>"; };
 		775C96A9278B2E1100A9BEA0 /* swiftgen.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = swiftgen.yml; sourceTree = "<group>"; };
 		775C96AF278B33E200A9BEA0 /* Assets+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Assets+Generated.swift"; sourceTree = "<group>"; };
-		775C96B1278B5B3800A9BEA0 /* NavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBar.swift; sourceTree = "<group>"; };
+		775C96B1278B5B3800A9BEA0 /* FillinNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FillinNavigationBar.swift; sourceTree = "<group>"; };
 		775C96B3278B61D100A9BEA0 /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
 		A23EAA42105DDEFDBD25F680 /* Pods-Fillin-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Fillin-iOS.debug.xcconfig"; path = "Target Support Files/Pods-Fillin-iOS/Pods-Fillin-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		EB6BBBE71164715C5939F205 /* Pods-Fillin-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Fillin-iOS.release.xcconfig"; path = "Target Support Files/Pods-Fillin-iOS/Pods-Fillin-iOS.release.xcconfig"; sourceTree = "<group>"; };
@@ -225,7 +225,7 @@
 		775C9668278ACF1B00A9BEA0 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				775C96B1278B5B3800A9BEA0 /* NavigationBar.swift */,
+				775C96B1278B5B3800A9BEA0 /* FillinNavigationBar.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -493,7 +493,7 @@
 				775C9649278ACBEA00A9BEA0 /* AppDelegate.swift in Sources */,
 				775C96A7278AD8E600A9BEA0 /* SplashViewController.swift in Sources */,
 				775C9696278AD89200A9BEA0 /* StudioMapViewController.swift in Sources */,
-				775C96B2278B5B3800A9BEA0 /* NavigationBar.swift in Sources */,
+				775C96B2278B5B3800A9BEA0 /* FillinNavigationBar.swift in Sources */,
 				775C969A278AD89F00A9BEA0 /* FilmRollViewController.swift in Sources */,
 				775C9674278ACF6600A9BEA0 /* TempModel.swift in Sources */,
 				775C96A2278AD8BB00A9BEA0 /* MyPageViewController.swift in Sources */,

--- a/Fillin-iOS/Fillin-iOS.xcodeproj/project.pbxproj
+++ b/Fillin-iOS/Fillin-iOS.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		775C96AA278B2E1100A9BEA0 /* swiftgen.yml in Resources */ = {isa = PBXBuildFile; fileRef = 775C96A9278B2E1100A9BEA0 /* swiftgen.yml */; };
 		775C96B0278B33E200A9BEA0 /* Assets+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C96AF278B33E200A9BEA0 /* Assets+Generated.swift */; };
 		775C96B2278B5B3800A9BEA0 /* NavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C96B1278B5B3800A9BEA0 /* NavigationBar.swift */; };
+		775C96B4278B61D100A9BEA0 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C96B3278B61D100A9BEA0 /* UIView+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -78,6 +79,7 @@
 		775C96A9278B2E1100A9BEA0 /* swiftgen.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = swiftgen.yml; sourceTree = "<group>"; };
 		775C96AF278B33E200A9BEA0 /* Assets+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Assets+Generated.swift"; sourceTree = "<group>"; };
 		775C96B1278B5B3800A9BEA0 /* NavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBar.swift; sourceTree = "<group>"; };
+		775C96B3278B61D100A9BEA0 /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
 		A23EAA42105DDEFDBD25F680 /* Pods-Fillin-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Fillin-iOS.debug.xcconfig"; path = "Target Support Files/Pods-Fillin-iOS/Pods-Fillin-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		EB6BBBE71164715C5939F205 /* Pods-Fillin-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Fillin-iOS.release.xcconfig"; path = "Target Support Files/Pods-Fillin-iOS/Pods-Fillin-iOS.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -204,6 +206,7 @@
 			children = (
 				775C967E278ACFFD00A9BEA0 /* UIColor+Extension.swift */,
 				775C9680278AD00100A9BEA0 /* UIFont+Extension.swift */,
+				775C96B3278B61D100A9BEA0 /* UIView+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -497,6 +500,7 @@
 				775C969E278AD8A900A9BEA0 /* AddPhotoViewController.swift in Sources */,
 				775C964B278ACBEA00A9BEA0 /* SceneDelegate.swift in Sources */,
 				775C9672278ACF5D00A9BEA0 /* TempClass.swift in Sources */,
+				775C96B4278B61D100A9BEA0 /* UIView+Extension.swift in Sources */,
 				775C9677278ACF8B00A9BEA0 /* MoyaLoggerPlugin.swift in Sources */,
 				775C9667278ACF0300A9BEA0 /* Const.swift in Sources */,
 				775C96B0278B33E200A9BEA0 /* Assets+Generated.swift in Sources */,

--- a/Fillin-iOS/Fillin-iOS.xcodeproj/project.pbxproj
+++ b/Fillin-iOS/Fillin-iOS.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		775C9674278ACF6600A9BEA0 /* TempModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C9673278ACF6600A9BEA0 /* TempModel.swift */; };
 		775C9677278ACF8B00A9BEA0 /* MoyaLoggerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C9676278ACF8B00A9BEA0 /* MoyaLoggerPlugin.swift */; };
 		775C9679278ACFB600A9BEA0 /* TempProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C9678278ACFB600A9BEA0 /* TempProtocol.swift */; };
-		775C967B278ACFBD00A9BEA0 /* TempView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C967A278ACFBD00A9BEA0 /* TempView.swift */; };
 		775C967D278ACFDD00A9BEA0 /* Xib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C967C278ACFDD00A9BEA0 /* Xib.swift */; };
 		775C967F278ACFFD00A9BEA0 /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C967E278ACFFD00A9BEA0 /* UIColor+Extension.swift */; };
 		775C9681278AD00100A9BEA0 /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C9680278AD00100A9BEA0 /* UIFont+Extension.swift */; };
@@ -40,6 +39,7 @@
 		775C96A8278AD8E600A9BEA0 /* SplashViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 775C96A6278AD8E600A9BEA0 /* SplashViewController.xib */; };
 		775C96AA278B2E1100A9BEA0 /* swiftgen.yml in Resources */ = {isa = PBXBuildFile; fileRef = 775C96A9278B2E1100A9BEA0 /* swiftgen.yml */; };
 		775C96B0278B33E200A9BEA0 /* Assets+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C96AF278B33E200A9BEA0 /* Assets+Generated.swift */; };
+		775C96B2278B5B3800A9BEA0 /* NavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775C96B1278B5B3800A9BEA0 /* NavigationBar.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -56,7 +56,6 @@
 		775C9673278ACF6600A9BEA0 /* TempModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempModel.swift; sourceTree = "<group>"; };
 		775C9676278ACF8B00A9BEA0 /* MoyaLoggerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoyaLoggerPlugin.swift; sourceTree = "<group>"; };
 		775C9678278ACFB600A9BEA0 /* TempProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempProtocol.swift; sourceTree = "<group>"; };
-		775C967A278ACFBD00A9BEA0 /* TempView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempView.swift; sourceTree = "<group>"; };
 		775C967C278ACFDD00A9BEA0 /* Xib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Xib.swift; sourceTree = "<group>"; };
 		775C967E278ACFFD00A9BEA0 /* UIColor+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
 		775C9680278AD00100A9BEA0 /* UIFont+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
@@ -78,6 +77,7 @@
 		775C96A6278AD8E600A9BEA0 /* SplashViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SplashViewController.xib; sourceTree = "<group>"; };
 		775C96A9278B2E1100A9BEA0 /* swiftgen.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = swiftgen.yml; sourceTree = "<group>"; };
 		775C96AF278B33E200A9BEA0 /* Assets+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Assets+Generated.swift"; sourceTree = "<group>"; };
+		775C96B1278B5B3800A9BEA0 /* NavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBar.swift; sourceTree = "<group>"; };
 		A23EAA42105DDEFDBD25F680 /* Pods-Fillin-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Fillin-iOS.debug.xcconfig"; path = "Target Support Files/Pods-Fillin-iOS/Pods-Fillin-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		EB6BBBE71164715C5939F205 /* Pods-Fillin-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Fillin-iOS.release.xcconfig"; path = "Target Support Files/Pods-Fillin-iOS/Pods-Fillin-iOS.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -222,7 +222,7 @@
 		775C9668278ACF1B00A9BEA0 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				775C967A278ACFBD00A9BEA0 /* TempView.swift */,
+				775C96B1278B5B3800A9BEA0 /* NavigationBar.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -489,8 +489,8 @@
 				775C9679278ACFB600A9BEA0 /* TempProtocol.swift in Sources */,
 				775C9649278ACBEA00A9BEA0 /* AppDelegate.swift in Sources */,
 				775C96A7278AD8E600A9BEA0 /* SplashViewController.swift in Sources */,
-				775C967B278ACFBD00A9BEA0 /* TempView.swift in Sources */,
 				775C9696278AD89200A9BEA0 /* StudioMapViewController.swift in Sources */,
+				775C96B2278B5B3800A9BEA0 /* NavigationBar.swift in Sources */,
 				775C969A278AD89F00A9BEA0 /* FilmRollViewController.swift in Sources */,
 				775C9674278ACF6600A9BEA0 /* TempModel.swift in Sources */,
 				775C96A2278AD8BB00A9BEA0 /* MyPageViewController.swift in Sources */,

--- a/Fillin-iOS/Fillin-iOS/Resources/Extensions/UIView+Extension.swift
+++ b/Fillin-iOS/Fillin-iOS/Resources/Extensions/UIView+Extension.swift
@@ -1,0 +1,15 @@
+//
+//  UIView+Extension.swift
+//  Fillin-iOS
+//
+//  Created by Yi Joon Choi on 2022/01/10.
+//
+
+import Foundation
+import UIKit
+
+extension UIView {
+    func addSubviews(_ view: [UIView]) {
+        view.forEach { self.addSubview($0) }
+    }
+}

--- a/Fillin-iOS/Fillin-iOS/Sources/Views/FillinNavigationBar.swift
+++ b/Fillin-iOS/Fillin-iOS/Sources/Views/FillinNavigationBar.swift
@@ -1,5 +1,5 @@
 //
-//  NavigationBar.swift
+//  FillinNavigationBar.swift
 //  Fillin-iOS
 //
 //  Created by Yi Joon Choi on 2022/01/10.
@@ -12,9 +12,9 @@ import Then
 /*
  공통으로 사용할 수 있도록 만들어둔 네비게이션 바 입니다.
  
- 1) NavigationBar에는 공통으로 필요한 요소들을 구현해둔 상태
- 2) NavigationBar를 상속받은 뷰 생성
-
+ 1) FillinNavigationBar에는 공통으로 필요한 요소들을 구현해둔 상태에요.
+ 2) 해당 ViewController로 가서 FillinNavigationBar를 상속받은 UIView 생성 (ex: navigationBar)
+ 3) navigationBar.popViewController = { self.navigationController?.popViewController(animated: true) } 를 추가해요.
 */
 
 class FilinNavigationBar: UIView {

--- a/Fillin-iOS/Fillin-iOS/Sources/Views/FillinNavigationBar.swift
+++ b/Fillin-iOS/Fillin-iOS/Sources/Views/FillinNavigationBar.swift
@@ -17,9 +17,11 @@ import Then
 
 */
 
-class NavigationBar: UIView {
+class FilinNavigationBar: UIView {
     
     // MARK: - Properties
+    
+    var popViewController: (() -> Void)?
     
     private let backButton = UIButton().then {
         $0.setImage(Asset.btnBack.image, for: .normal)
@@ -70,7 +72,7 @@ class NavigationBar: UIView {
     // MARK: - @objc
     
     @objc func touchBackButton(_ sender: UIButton) {
-        print("touchBackButton")
+        popViewController?()
     }
     
     @objc func touchLogoButton(_ sender: UIButton) {

--- a/Fillin-iOS/Fillin-iOS/Sources/Views/NavigationBar.swift
+++ b/Fillin-iOS/Fillin-iOS/Sources/Views/NavigationBar.swift
@@ -18,11 +18,62 @@ import Then
 */
 
 class NavigationBar: UIView {
+    
+    // MARK: - Properties
+    
     private let backButton = UIButton().then {
         $0.setImage(Asset.btnBack.image, for: .normal)
+        $0.addTarget(self, action: #selector(touchBackButton(_:)), for: .touchUpInside)
     }
     
     private let logoButton = UIButton().then {
         $0.setImage(Asset.btnHome.image, for: .normal)
+        $0.addTarget(self, action: #selector(touchLogoButton(_:)), for: .touchUpInside)
+    }
+    
+    // MARK: - Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configUI()
+        setupAutoLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configUI()
+        setupAutoLayout()
+    }
+    
+    // MARK: - Custom Method
+    
+    private func configUI() {
+        backgroundColor = .fillinBlack
+    }
+    
+    private func setupAutoLayout() {
+        addSubviews([backButton, logoButton])
+        
+        backButton.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(18)
+            make.centerY.equalToSuperview()
+        }
+        
+        logoButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.centerY.equalToSuperview()
+            make.width.equalTo(86)
+            make.height.equalTo(32)
+        }
+    }
+    
+    // MARK: - @objc
+    
+    @objc func touchBackButton(_ sender: UIButton) {
+        print("touchBackButton")
+    }
+    
+    @objc func touchLogoButton(_ sender: UIButton) {
+        print("touchLogoButton")
     }
 }

--- a/Fillin-iOS/Fillin-iOS/Sources/Views/NavigationBar.swift
+++ b/Fillin-iOS/Fillin-iOS/Sources/Views/NavigationBar.swift
@@ -1,0 +1,28 @@
+//
+//  NavigationBar.swift
+//  Fillin-iOS
+//
+//  Created by Yi Joon Choi on 2022/01/10.
+//
+
+import Foundation
+import SnapKit
+import Then
+
+/*
+ 공통으로 사용할 수 있도록 만들어둔 네비게이션 바 입니다.
+ 
+ 1) NavigationBar에는 공통으로 필요한 요소들을 구현해둔 상태
+ 2) NavigationBar를 상속받은 뷰 생성
+
+*/
+
+class NavigationBar: UIView {
+    private let backButton = UIButton().then {
+        $0.setImage(Asset.btnBack.image, for: .normal)
+    }
+    
+    private let logoButton = UIButton().then {
+        $0.setImage(Asset.btnHome.image, for: .normal)
+    }
+}

--- a/Fillin-iOS/Fillin-iOS/Sources/Views/TempView.swift
+++ b/Fillin-iOS/Fillin-iOS/Sources/Views/TempView.swift
@@ -1,8 +1,0 @@
-//
-//  TempView.swift
-//  Fillin-iOS
-//
-//  Created by Yi Joon Choi on 2022/01/09.
-//
-
-import Foundation


### PR DESCRIPTION
## 🐯 PR 요약

🌱 작업한 브랜치
- feature/#3

🌱 작업한 내용
- 코드베이스로 작업시 addView를 더욱 더 간편하게 할 수 있는 extension을 추가했습니다.
- 필린 로고가 있는 커스텀 네비게이션 바를 코드베이스로 작업했습니다. (나중에 스튜디오 맵 버전도 제작예정입니다)
- 사용 방법을 주석으로 처리했습니다. (참고바람!)
- backButton을 누르면 일어나는 일들을 클로져로 처리했습니다.

## 📸 스크린샷
|기능|스크린샷|기능|스크린샷|
|:--:|:--:|:--:|:--:|
|전체화면|![Simulator Screen Shot - iPhone 12 mini - 2022-01-10 at 04 24 06](https://user-images.githubusercontent.com/69078056/148698051-023a99ea-8535-4e4c-b0ed-08e4abd9e29b.png)|GIF|![ezgif com-gif-maker (15)](https://user-images.githubusercontent.com/69078056/148698059-c3d24e92-26c8-4c6c-be4d-799521cfde54.gif)|


## 📮 관련 이슈
- Resolved: #3 
