### PR TITLE
🔨[FIX]  #95 - 회원가입 뒤 가는 뷰에서 네비게이션 컨트롤러 넣기

### DIFF
--- a/Fillin-iOS/Fillin-iOS/Sources/ViewControllers/LoginViewController/LoginViewController.swift
+++ b/Fillin-iOS/Fillin-iOS/Sources/ViewControllers/LoginViewController/LoginViewController.swift
@@ -104,11 +104,10 @@ extension LoginViewController {
         authorizationController.performRequests()
     }
     func presentToMain() {
-        let homeVC = HomeViewController()
-        homeVC.modalPresentationStyle = .overFullScreen
-        self.present(homeVC, animated: true) {
-            //      UserDefaults.standard.set(false, forKey: Const.UserDefaultsKey.isOnboarding)
-        }
+        let mainNavigationController = UINavigationController(rootViewController: HomeViewController())
+        mainNavigationController.modalPresentationStyle = .fullScreen
+        mainNavigationController.modalTransitionStyle = .crossDissolve
+        self.present(mainNavigationController, animated: true, completion: nil)
     }
 }
 


### PR DESCRIPTION
## 🐯 PR 요약

🌱 작업한 브랜치
- feature/#95

🌱 작업한 내용
- 회원가입 뒤 가는 뷰에서 네비게이션 컨트롤러 넣어서 푸시, 팝 살리기

## 📮 관련 이슈
- Resolved: #95 
