### PR TITLE
🔨[FIX] #129 - 지도뷰 현상소 마커 중복클릭 방지

### DIFF
--- a/Fillin-iOS/Fillin-iOS/Sources/ViewControllers/SplashViewController/SplashViewController.swift
+++ b/Fillin-iOS/Fillin-iOS/Sources/ViewControllers/SplashViewController/SplashViewController.swift
@@ -52,7 +52,7 @@ extension SplashViewController {
     }
     
     private func presentToOnboarding() {
-        let onboardingNavigationController = UINavigationController(rootViewController: OnboardingFirstViewController())
+        let onboardingNavigationController = UINavigationController(rootViewController: OnboardingViewController())
         onboardingNavigationController.modalPresentationStyle = .fullScreen
         onboardingNavigationController.modalTransitionStyle = .crossDissolve
         self.present(onboardingNavigationController, animated: true, completion: nil)

--- a/Fillin-iOS/Fillin-iOS/Sources/ViewControllers/StudioMapViewController/StudioMapViewController.swift
+++ b/Fillin-iOS/Fillin-iOS/Sources/ViewControllers/StudioMapViewController/StudioMapViewController.swift
@@ -181,26 +181,25 @@ extension StudioMapViewController {
       let markerInfo = Studio(id: $0.id, lati: $0.lati, long: $0.long)
       marker.iconImage = NMFOverlayImage(image: Asset.icnStudio.image)
       
+      self.selectedMarkerInfo  = markerInfo
+      StudioMapViewController.selectedMarkerID = markerInfo.id
+      self.studioInfoWithAPI(studioID: markerInfo.id)
+      
       marker.touchHandler = { [weak self] (overlay: NMFOverlay) -> Bool in
         if self?.selectedMarker == nil { /// 클릭했던 현상소가 없는 경우 (지도뷰 처음 들어올 떄)
           self?.selectedMarker = marker
           self?.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudioSelected.image)
           self?.showBottomSheet()
-          self?.selectedMarkerInfo  = markerInfo
-          StudioMapViewController.selectedMarkerID = markerInfo.id
-          self?.studioInfoWithAPI(studioID: markerInfo.id)
-          // TODO: - 카메라 이동 (통신 필요)
         } else {
           if self?.selectedMarker == marker { /// 클릭했던 현상소를 다시 클릭하는 경우
-            self?.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudio.image)
             self?.selectedMarker = nil
+            self?.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudio.image)
             self?.hideBottomSheetAndGoBack()
           } else { /// 다른 현상소 클릭
             self?.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudio.image)
             self?.selectedMarker = marker
             self?.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudioSelected.image)
             self?.showBottomSheet()
-            // TODO: - 카메라 이동 (통신 필요)
           }
         }
         return true

--- a/Fillin-iOS/Fillin-iOS/Sources/ViewControllers/StudioMapViewController/StudioMapViewController.swift
+++ b/Fillin-iOS/Fillin-iOS/Sources/ViewControllers/StudioMapViewController/StudioMapViewController.swift
@@ -86,16 +86,12 @@ class StudioMapViewController: UIViewController {
     layoutMyLocationButton()
     layoutSearchView()
     layoutNavigaionBar()
+    getBottomSheetInfo()
     totalStudioWithAPI()
     setLatLngNotification()
-    showtmpStudioMarker()
+    tmpSetupMarker()
     setupBottomSheetUI()
     setupBottomSheetGestureRecognizer()
-    getBottomSheetInfo()
-  }
-  
-  override func viewDidAppear(_ animated: Bool) {
-    getBottomSheetInfo()
   }
   
   // MARK: - init
@@ -113,26 +109,55 @@ class StudioMapViewController: UIViewController {
 extension StudioMapViewController {
   
   /// 서버 부활되기 전까지 현상소 관련 기능 테스트할 임시 함수 (네이버 그린팩토리에 현상소 표시해줌)
-  func showtmpStudioMarker() {
+  func tmpSetupMarker() {
     let markertmp = NMFMarker(position: NMGLatLng(lat: 37.35940010181669, lng: 127.10475679570187))
     markertmp.iconImage = NMFOverlayImage(image: Asset.icnStudio.image)
     markertmp.mapView = self.mapView.mapView
     
-    /// 클릭 시 이벤트 설정
-    markertmp.touchHandler = { [weak self] (overlay: NMFOverlay) -> Bool in
-      if self?.clickCount == 1 { /// 이미 마커가 클릭된 경우 (중복 클릭 허용안함)
-        self?.clickCount = 0
-        markertmp.iconImage = NMFOverlayImage(image: Asset.icnStudio.image)
-        self?.hideBottomSheetAndGoBack()
-      } else {
-        self?.clickCount = 1
-        markertmp.iconImage = NMFOverlayImage(image: Asset.icnStudioSelected.image)
+    let secondMarkertmp = NMFMarker(position: NMGLatLng(lat: 37.36161841308457, lng: 127.10566240106306))
+    secondMarkertmp.iconImage = NMFOverlayImage(image: Asset.icnStudio.image)
+    secondMarkertmp.mapView = self.mapView.mapView
+    
+    secondMarkertmp.touchHandler = { [weak self] (overlay: NMFOverlay) -> Bool in
+      if self?.selectedMarker == nil { /// 클릭했던 현상소가 없는 경우 (지도뷰 처음 들어올 떄)
+        self?.selectedMarker = secondMarkertmp
+        self?.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudioSelected.image)
         self?.showBottomSheet()
+      } else {
+        if self?.selectedMarker == secondMarkertmp { /// 클릭했던 현상소를 다시 클릭하는 경우
+          self?.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudio.image)
+          self?.hideBottomSheetAndGoBack()
+        } else { /// 다른 현상소 클릭
+          self?.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudio.image)
+          self?.selectedMarker = secondMarkertmp
+          self?.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudioSelected.image)
+          self?.showBottomSheet()
+        }
+      }
+      return true
+    }
+  
+    markertmp.touchHandler = { [weak self] (overlay: NMFOverlay) -> Bool in
+      if self?.selectedMarker == nil { /// 클릭했던 현상소가 없는 경우 (지도뷰 처음 들어올 떄)
+        self?.selectedMarker = markertmp
+        self?.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudioSelected.image)
+        self?.showBottomSheet()
+      } else {
+        if self?.selectedMarker == markertmp { /// 클릭했던 현상소를 다시 클릭하는 경우
+          self?.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudio.image)
+          self?.selectedMarker = nil
+          self?.hideBottomSheetAndGoBack()
+        } else { /// 다른 현상소 클릭
+          self?.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudio.image)
+          self?.selectedMarker = markertmp
+          self?.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudioSelected.image)
+          self?.showBottomSheet()
+        }
       }
       return true
     }
   }
-    
+  
   private func setUpMapView() {
     view.addSubview(mapView)
     let locationOverlay = mapView.mapView.locationOverlay
@@ -157,16 +182,26 @@ extension StudioMapViewController {
       marker.iconImage = NMFOverlayImage(image: Asset.icnStudio.image)
       
       marker.touchHandler = { [weak self] (overlay: NMFOverlay) -> Bool in
-        if self?.clickCount == 1 { /// 이미 마커가 클릭된 경우 (중복 클릭 허용안함)
-          self?.clickCount = 0
-          self?.hideBottomSheetAndGoBack()
-          marker.iconImage = NMFOverlayImage(image: Asset.icnStudio.image)
-        } else {
-          self?.clickCount = 1
+        if self?.selectedMarker == nil { /// 클릭했던 현상소가 없는 경우 (지도뷰 처음 들어올 떄)
           self?.selectedMarker = marker
+          self?.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudioSelected.image)
+          self?.showBottomSheet()
           self?.selectedMarkerInfo  = markerInfo
           StudioMapViewController.selectedMarkerID = markerInfo.id
           self?.studioInfoWithAPI(studioID: markerInfo.id)
+          // TODO: - 카메라 이동 (통신 필요)
+        } else {
+          if self?.selectedMarker == marker { /// 클릭했던 현상소를 다시 클릭하는 경우
+            self?.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudio.image)
+            self?.selectedMarker = nil
+            self?.hideBottomSheetAndGoBack()
+          } else { /// 다른 현상소 클릭
+            self?.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudio.image)
+            self?.selectedMarker = marker
+            self?.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudioSelected.image)
+            self?.showBottomSheet()
+            // TODO: - 카메라 이동 (통신 필요)
+          }
         }
         return true
       }
@@ -177,9 +212,9 @@ extension StudioMapViewController {
   func getBottomSheetInfo() {
     StudioMapViewController.name = "필린 현상소"
     StudioMapViewController.address = "솝트시 앱잼구 필린동 아요로 12번길 13"
-    StudioMapViewController.time = "open 10:00-21:00"
+    StudioMapViewController.time = "open 00:00-24:00"
     StudioMapViewController.tel = "010-1234-5678"
-    StudioMapViewController.price = "컬러 5000원"
+    StudioMapViewController.price = "컬러 5000000000원"
     StudioMapViewController.site = ""
     
 //    StudioMapViewController.name = self.serverStudioInfo?.studio.name
@@ -263,12 +298,6 @@ extension StudioMapViewController {
     newVC.modalTransitionStyle = .crossDissolve
     newVC.modalPresentationStyle = .fullScreen
     self.present(newVC, animated: true, completion: nil)
-  }
-  
-  @objc func changeMarkerObserver(_ notification: Notification) {
-    selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnPlaceBig.image)
-    selectedMarker = nil
-    clickCount = 0
   }
 
   @objc func touchLocationButton(_ sender: UIButton) {
@@ -444,6 +473,8 @@ extension StudioMapViewController {
   func hideBottomSheetAndGoBack() {
     let safeAreaHeight = view.safeAreaLayoutGuide.layoutFrame.height
     let bottomPadding = view.safeAreaInsets.bottom
+    self.selectedMarker?.iconImage = NMFOverlayImage(image: Asset.icnStudio.image)
+    self.selectedMarker = nil
     bottomSheetViewTopConstraint.constant = safeAreaHeight + bottomPadding
     UIView.animate(withDuration: 0.2, delay: 0, options: .curveEaseOut, animations: {
       self.view.layoutIfNeeded()
@@ -454,10 +485,6 @@ extension StudioMapViewController {
     guard let nearestVal = values.min(by: { abs(number - $0) < abs(number - $1) })
     else { return number }
     return nearestVal
-  }
-  
-  func setNotification() {
-    NotificationCenter.default.post(name: NSNotification.Name.changeMarker, object: nil, userInfo: nil)
   }
 
   func changeScrollEnabled() {
@@ -495,7 +522,6 @@ extension StudioMapViewController {
       }
     case .ended:
       if velocity.y > 1500 {
-        setNotification()
         hideBottomSheetAndGoBack()
         return
       }
@@ -508,7 +534,6 @@ extension StudioMapViewController {
       } else if nearestValue == defaultPadding {
         showBottomSheet(atState: .normal)
       } else {
-        setNotification()
         hideBottomSheetAndGoBack()
       }
     default:


### PR DESCRIPTION
## 🐯 PR 요약

🌱 작업한 브랜치
- feature/#129

🌱 작업한 내용
- 현상소 아이콘 클릭 시 이벤트를 중복 클릭이 안되게 경우를 나눠서 코드를 다시 짰습니다. (아래 사진 참고)

🌱 PR Point
- 토큰 안나와서 현상소 두 개 임시로 만드느라 중복으로 쓰여진 코드들이 있는데, "아래 사진에 있는 함수 구조"만 봐주셔도 될 것 같습니다! (경우가 크게 3가지여서, 조건문 통해서 이부분을 다시 짰는데 더 효율적으로 코드 짜는 방법이 생각나면 수정해보겠습니다. 혹시나 생각나시면 알려주세요~)

## 📌 코드 설명
|코드|구조|
|:--:|:--:|
|<img width="350" alt="스크린샷 2022-03-03 오후 11 48 36" src="https://user-images.githubusercontent.com/76610340/156588502-faabb249-2325-45ad-8c6d-1e5d3632e8a6.png">|<img width="350" alt="스크린샷 2022-03-03 오후 11 42 19" src="https://user-images.githubusercontent.com/76610340/156588372-8bc50d8c-6409-4aaf-b55d-e93ab5896264.png">|

## 📸 앱 실행 스크린샷
|실행장면||
|:--:|:--:|
|<img width="300" src="https://user-images.githubusercontent.com/76610340/156589902-7605990a-7d95-4b8f-9642-8d8c02af2c96.gif">| - 토큰 유효기간으로 인한 통신 불량으로 현상소 클릭 시 현상소가 지도 가운데로 가게 하는 기능과 현상소 상세정보 바뀌는 기능은 정지된 상태입니다. |


## 📮 관련 이슈
- Resolved: #129
